### PR TITLE
Anonymous reporting

### DIFF
--- a/src/main/java/com/orangecheese/reports/command/report/ReportBugCommandArgument.java
+++ b/src/main/java/com/orangecheese/reports/command/report/ReportBugCommandArgument.java
@@ -8,6 +8,7 @@ import com.orangecheese.reports.core.http.request.report.CreateBugReportRequest;
 import com.orangecheese.reports.core.io.ContainerCache;
 import com.orangecheese.reports.service.chatprompt.ChatPrompt;
 import com.orangecheese.reports.service.chatprompt.ChatPromptArgument;
+import com.orangecheese.reports.service.chatprompt.ChatPromptCondition;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
@@ -26,6 +27,7 @@ public class ReportBugCommandArgument implements ICommandArgument {
         ChatPrompt prompt = new ChatPrompt(player, promptArguments -> {
             String message = promptArguments[0];
             String stepsToReproduce = promptArguments[1];
+            boolean anonymous = promptArguments[2].equalsIgnoreCase("yes");
 
             String accessToken = containerCache.getAccessToken();
 
@@ -33,6 +35,7 @@ public class ReportBugCommandArgument implements ICommandArgument {
                     accessToken,
                     player,
                     message,
+                    anonymous,
                     stepsToReproduce,
                     () -> player.sendMessage(ChatColor.GREEN + "A new bug report has been submitted!"));
 
@@ -41,6 +44,12 @@ public class ReportBugCommandArgument implements ICommandArgument {
 
         prompt.addArgument(new ChatPromptArgument("Describe the bug that you had encountered:"));
         prompt.addArgument(new ChatPromptArgument("Describe the steps to reproduce the bug:"));
+
+        ChatPromptArgument anonymousChatPromptArgument = new ChatPromptArgument("Would you like to report anonymously? (Yes/No)");
+        anonymousChatPromptArgument.setCondition(new ChatPromptCondition(
+                argument -> argument.matches("(?i)^(yes|no)$"),
+                "You have given an invalid yes/no value! Please try again."));
+        prompt.addArgument(anonymousChatPromptArgument);
 
         prompt.start();
     }

--- a/src/main/java/com/orangecheese/reports/command/report/ReportSuggestionCommandArgument.java
+++ b/src/main/java/com/orangecheese/reports/command/report/ReportSuggestionCommandArgument.java
@@ -8,6 +8,7 @@ import com.orangecheese.reports.core.http.request.report.CreateSuggestionReportR
 import com.orangecheese.reports.core.io.ContainerCache;
 import com.orangecheese.reports.service.chatprompt.ChatPrompt;
 import com.orangecheese.reports.service.chatprompt.ChatPromptArgument;
+import com.orangecheese.reports.service.chatprompt.ChatPromptCondition;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
@@ -25,6 +26,7 @@ public class ReportSuggestionCommandArgument implements ICommandArgument {
     public void execute(Player player, String[] arguments, BaseCommand baseCommand) {
         ChatPrompt prompt = new ChatPrompt(player, promptArguments -> {
             String message = promptArguments[0];
+            boolean anonymous = promptArguments[1].equalsIgnoreCase("yes");
 
             String accessToken = containerCache.getAccessToken();
 
@@ -32,12 +34,19 @@ public class ReportSuggestionCommandArgument implements ICommandArgument {
                     accessToken,
                     player,
                     message,
+                    anonymous,
                     () -> player.sendMessage(ChatColor.GREEN + "A new suggestion report has been submitted!"));
 
             apiManager.makeRequest(reportRequest);
         });
 
         prompt.addArgument(new ChatPromptArgument("Describe the suggestion that you would like to submit:"));
+
+        ChatPromptArgument anonymousChatPromptArgument = new ChatPromptArgument("Would you like to report anonymously? (Yes/No)");
+        anonymousChatPromptArgument.setCondition(new ChatPromptCondition(
+                argument -> argument.matches("(?i)^(yes|no)$"),
+                "You have given an invalid yes/no value! Please try again."));
+        prompt.addArgument(anonymousChatPromptArgument);
 
         prompt.start();
     }

--- a/src/main/java/com/orangecheese/reports/core/http/request/report/CreateBugReportRequest.java
+++ b/src/main/java/com/orangecheese/reports/core/http/request/report/CreateBugReportRequest.java
@@ -6,8 +6,8 @@ import org.bukkit.entity.Player;
 public class CreateBugReportRequest extends CreateReportRequest {
     private final String stepsToReproduce;
 
-    public CreateBugReportRequest(String accessToken, Player player, String message, String stepsToReproduce, Runnable onSuccess) {
-        super("create-bug-report", accessToken, player, message, onSuccess);
+    public CreateBugReportRequest(String accessToken, Player player, String message, boolean anonymous, String stepsToReproduce, Runnable onSuccess) {
+        super("create-bug-report", accessToken, player, message, anonymous, onSuccess);
         this.stepsToReproduce = stepsToReproduce;
     }
 

--- a/src/main/java/com/orangecheese/reports/core/http/request/report/CreatePlayerReportRequest.java
+++ b/src/main/java/com/orangecheese/reports/core/http/request/report/CreatePlayerReportRequest.java
@@ -8,8 +8,8 @@ import java.util.UUID;
 public class CreatePlayerReportRequest extends CreateReportRequest {
     private final UUID playerUuid;
 
-    public CreatePlayerReportRequest(String accessToken, Player player, String message, UUID playerUuid, Runnable onSuccess) {
-        super("create-player-report", accessToken, player, message, onSuccess);
+    public CreatePlayerReportRequest(String accessToken, Player player, String message, boolean anonymous, UUID playerUuid, Runnable onSuccess) {
+        super("create-player-report", accessToken, player, message, anonymous, onSuccess);
         this.playerUuid = playerUuid;
     }
 

--- a/src/main/java/com/orangecheese/reports/core/http/request/report/CreateReportRequest.java
+++ b/src/main/java/com/orangecheese/reports/core/http/request/report/CreateReportRequest.java
@@ -16,11 +16,14 @@ public abstract class CreateReportRequest extends HTTPRequestWithResponse<EmptyR
 
     private final String message;
 
+    private final boolean anonymous;
+
     public CreateReportRequest(
             String endpoint,
             String accessToken,
             Player player,
             String message,
+            boolean anonymous,
             Runnable onSuccess) {
         super(
                 "report/" + endpoint,
@@ -30,6 +33,7 @@ public abstract class CreateReportRequest extends HTTPRequestWithResponse<EmptyR
         this.accessToken = accessToken;
         this.player = player;
         this.message = message;
+        this.anonymous = anonymous;
     }
 
     @Override
@@ -48,7 +52,8 @@ public abstract class CreateReportRequest extends HTTPRequestWithResponse<EmptyR
     public JsonObject generateJson() {
         JsonObject json = new JsonObject();
         json.addProperty("accessToken", accessToken);
-        json.addProperty("reporterUuid", player.getUniqueId().toString());
+        if(!anonymous)
+            json.addProperty("reporterUuid", player.getUniqueId().toString());
         json.addProperty("message", message);
 
         json = appendJson(json);

--- a/src/main/java/com/orangecheese/reports/core/http/request/report/CreateSuggestionReportRequest.java
+++ b/src/main/java/com/orangecheese/reports/core/http/request/report/CreateSuggestionReportRequest.java
@@ -4,8 +4,8 @@ import com.google.gson.JsonObject;
 import org.bukkit.entity.Player;
 
 public class CreateSuggestionReportRequest extends CreateReportRequest {
-    public CreateSuggestionReportRequest(String accessToken, Player player, String message, Runnable onSuccess) {
-        super("create-suggestion-report", accessToken, player, message, onSuccess);
+    public CreateSuggestionReportRequest(String accessToken, Player player, String message, boolean anonymous, Runnable onSuccess) {
+        super("create-suggestion-report", accessToken, player, message, anonymous, onSuccess);
     }
 
     @Override

--- a/src/main/java/com/orangecheese/reports/core/http/response/ReportResponse.java
+++ b/src/main/java/com/orangecheese/reports/core/http/response/ReportResponse.java
@@ -1,5 +1,6 @@
 package com.orangecheese.reports.core.http.response;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import java.text.DateFormat;
@@ -47,7 +48,10 @@ public class ReportResponse<T> {
     public static <T> ReportResponse<T> fromJson(JsonObject json, T attributes) {
         int id = json.get("id").getAsInt();
         int containerId = json.get("container_id").getAsInt();
-        UUID reporterUuid = UUID.fromString(json.get("reporter_uuid").getAsString());
+
+        JsonElement reporterUuidElement = json.get("reporter_uuid");
+        UUID reporterUuid = !reporterUuidElement.isJsonNull() ? UUID.fromString(reporterUuidElement.getAsString()) : null;
+
         String message = json.get("message").getAsString();
         boolean resolved = json.get("resolved").getAsBoolean();
 

--- a/src/main/java/com/orangecheese/reports/service/chatprompt/ChatPromptArgument.java
+++ b/src/main/java/com/orangecheese/reports/service/chatprompt/ChatPromptArgument.java
@@ -47,10 +47,11 @@ public class ChatPromptArgument {
     public String getConditionMessage() {
         String message = condition.getMessage();
 
-        ChatPromptPlaceholder placeholder = getPlaceholder();
-        String replacementKey = "%" + placeholder.getKey() + "%";
-        String transformedMessage = placeholder.transform(value);
-        message = message.replace(replacementKey, transformedMessage);
+        if(placeholder != null) {
+            String replacementKey = "%" + placeholder.getKey() + "%";
+            String transformedMessage = placeholder.transform(value);
+            message = message.replace(replacementKey, transformedMessage);
+        }
 
         return message;
     }


### PR DESCRIPTION
- Added a chat prompt to the report creation command that asks to report anonymously or not.
- Made the Reporter's UUID nullable by requesting a report submission and generating a response from read requests.
- Changed the display name of the reporter to "Anonymous" in the reports menu if the report has no reporter tracked.